### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-bullseye
+WORKDIR /data
+#RUN groupadd -r node -g 433 && \
+#    useradd -u 431 -r -g node --home /home/node/ --create-home -s /sbin/nologin -c "Docker image user" node
+COPY . .
+RUN chown -R node:node /data
+USER node
+RUN npm install
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: ai-writing-assistant
     container_name: ai-assistant
     environment:
-      OPENAI_API_KEY: "sk-fWY75n1TMkS76PBT3BlbkFJiY0HoJrRGNMd2x46AfqX"
+      OPENAI_API_KEY: "YOUR_API_KEY"
     ports:
       - 3001:3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3.8'
 services:
-  aptly:
+  ai-writing-assistant:
     build:
         context: .
         dockerfile: Dockerfile
     image: ai-writing-assistant
     container_name: ai-assistant
     environment:
-      - OPENAI_API_KEY=""
+      OPENAI_API_KEY: "sk-fWY75n1TMkS76PBT3BlbkFJiY0HoJrRGNMd2x46AfqX"
     ports:
-      - 3000:3000
+      - 3001:3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  aptly:
+    build:
+        context: .
+        dockerfile: Dockerfile
+    image: ai-writing-assistant
+    container_name: ai-assistant
+    environment:
+      - OPENAI_API_KEY=""
+    ports:
+      - 3000:3000
+


### PR DESCRIPTION
This is a really simple Docker image to deploy AI-Writing Assistant. 

Usage: 
```bash
docker-compose build # build the image
docker-compose up     # run the image
```

You just need to edit `docker-compose.yml` to add OPENAI_API_TOKEN